### PR TITLE
Not contain set

### DIFF
--- a/macros/schema_tests/table_shape/expect_table_columns_not_to_contain_set.sql
+++ b/macros/schema_tests/table_shape/expect_table_columns_not_to_contain_set.sql
@@ -1,4 +1,4 @@
-{%- test expect_table_columns_to_contain_set(model, column_list, transform="upper") -%}
+{%- test expect_table_columns_not_to_contain_set(model, column_list, transform="upper") -%}
 {%- if execute -%}
     {%- set column_list = column_list | map(transform) | list -%}
     {%- set relation_column_names = dbt_expectations._get_column_list(model, transform) -%}

--- a/macros/schema_tests/table_shape/expect_table_columns_not_to_contain_set.sql
+++ b/macros/schema_tests/table_shape/expect_table_columns_not_to_contain_set.sql
@@ -1,0 +1,29 @@
+{%- test expect_table_columns_to_contain_set(model, column_list, transform="upper") -%}
+{%- if execute -%}
+    {%- set column_list = column_list | map(transform) | list -%}
+    {%- set relation_column_names = dbt_expectations._get_column_list(model, transform) -%}
+    {%- set matching_columns = dbt_expectations._list_intersect(column_list, relation_column_names) -%}
+    with relation_columns as (
+
+        {% for col_name in relation_column_names %}
+        select cast('{{ col_name }}' as {{ dbt_utils.type_string() }}) as relation_column
+        {% if not loop.last %}union all{% endif %}
+        {% endfor %}
+    ),
+    input_columns as (
+
+        {% for col_name in column_list %}
+        select cast('{{ col_name }}' as {{ dbt_utils.type_string() }}) as input_column
+        {% if not loop.last %}union all{% endif %}
+        {% endfor %}
+    )
+    select *
+    from
+        input_columns i
+        left join
+        relation_columns r on r.relation_column = i.input_column
+    where
+        -- catch any column in input list that is not in the list of table columns
+        r.relation_column is not null
+{%- endif -%}
+{%- endtest -%}


### PR DESCRIPTION
Adds table shape test to look for the population of certain columns. Test is a copy of the expect_table_columns_to_contain_set with the final where clause changed

Specific use case is Servicenow data loaded via Fivetran.  Fivetran will not add a _fivetran_deleted column to the Servicenow object unless and until at least 1 record from the source object was deleted.  We've added this test to any Servicenow source that does not already have that column.  This allows us to leave Fivetran set to bring in all new columns and only notify us if _fivetran_deleted was added and needs to be addressed in the dbt project